### PR TITLE
feat(soundtrack): implement playlist-based soundtrack system

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,17 +1,22 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { APP_GUARD } from '@nestjs/core/constants';
+
+import { AppController } from './app.controller';
+import { AppService } from './app.service';
+
+import { AuthModule } from './auth/module/auth.module';
+import { UserModule } from './user/user.module';
+import { AdminModule } from './auth/module/admin.module';
+import { SuperadminModule } from './auth/module/superadmin.module';
+
+import { AdminAuthController } from './auth/controller/admin.controller';
+import { SuperadminController } from './auth/controller/superadmin.controller';
+
 import { JwtAuthGuard } from './auth/jwt/jwt-auth.guard';
 import { RolesGuard } from './common/guards/roles.guard';
 import { GlobalAuthGuard } from './common/guards/global-auth.guard';
-import { APP_GUARD } from '@nestjs/core/constants';
-import { AppService } from './app.service';
-import { AdminAuthController } from './auth/controller/admin.controller';
-import { AppController } from './app.controller';
-import { SuperadminController } from './auth/controller/superadmin.controller';
-import { SuperadminModule } from './auth/module/superadmin.module';
-import { AdminModule } from './auth/module/admin.module';
-import { UserModule } from './user/user.module';
-import { AuthModule } from './auth/module/auth.module';
-import { MongooseModule } from '@nestjs/mongoose';
-import { Module } from '@nestjs/common';
+
 import { PlaylistModule } from './playlist/playlist.module';
 
 @Module({
@@ -23,7 +28,7 @@ import { PlaylistModule } from './playlist/playlist.module';
     UserModule,
     AdminModule,
     SuperadminModule,
-    PlaylistModule, // ✅ Tambahkan ini
+    PlaylistModule, // ✅ sudah include semua (playlist, soundtrack, dll)
   ],
   controllers: [
     AppController,
@@ -43,5 +48,3 @@ import { PlaylistModule } from './playlist/playlist.module';
   ],
 })
 export class AppModule {}
-
-

--- a/src/playlist/playlist.module.ts
+++ b/src/playlist/playlist.module.ts
@@ -1,20 +1,35 @@
 import { Module } from '@nestjs/common';
 import { MongooseModule } from '@nestjs/mongoose';
-import { PlaylistController } from './playlist.controller';
-import { PlaylistService } from './playlist.service';
+
 import { Playlist, PlaylistSchema } from './entities/playlist.entity';
 import { UserPlaylist, UserPlaylistSchema } from './entities/user-playlist.entity';
-import { PlaylistSeeder } from './playlist.seeder';
+
+
+import { PlaylistService } from './playlist.service';
+import { PlaylistController } from './playlist.controller';
+import { Soundtrack, SoundtrackSchema } from 'src/soundtrack/entities/soundtrack.entity';
+import { SoundtrackController } from 'src/soundtrack/soundtrack.controller';
+import { SoundtrackSeeder } from 'src/soundtrack/soundtrack.seeder';
+import { SoundtrackService } from 'src/soundtrack/soundtrack.service';
+
+
 
 @Module({
   imports: [
     MongooseModule.forFeature([
       { name: Playlist.name, schema: PlaylistSchema },
       { name: UserPlaylist.name, schema: UserPlaylistSchema },
+      { name: Soundtrack.name, schema: SoundtrackSchema },
     ]),
   ],
-  controllers: [PlaylistController],
-  providers: [PlaylistService, PlaylistSeeder],
-  exports: [PlaylistService],
+  controllers: [
+    PlaylistController,
+    SoundtrackController,
+  ],
+  providers: [
+    PlaylistService,
+    SoundtrackService,
+    SoundtrackSeeder, // ✅ daftarin seeder ke providers
+  ],
 })
 export class PlaylistModule {}

--- a/src/soundtrack/dto/soundtrack.dto.ts
+++ b/src/soundtrack/dto/soundtrack.dto.ts
@@ -1,0 +1,9 @@
+export class SoundtrackDto {
+    id: string;
+    title: string;
+    artist: string;
+    duration: number;
+    coverUrl: string;
+    audioUrl: string;
+  }
+  

--- a/src/soundtrack/entities/soundtrack.entity.ts
+++ b/src/soundtrack/entities/soundtrack.entity.ts
@@ -1,0 +1,29 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document, Types } from 'mongoose';
+
+@Schema({ timestamps: true })
+export class Soundtrack {
+  @Prop({ required: true })
+  title: string;
+
+  @Prop({ required: true })
+  artist: string;
+
+  @Prop({ required: true })
+  duration: number; // in seconds
+
+  @Prop({ required: true })
+  audioUrl: string;
+
+  @Prop({ required: true })
+  coverUrl: string;
+
+  @Prop({ type: Types.ObjectId, ref: 'Playlist', required: true })
+  playlistId: Types.ObjectId;
+
+  @Prop({ default: 0 })
+  playCount: number; // ✅ jumlah diputar
+}
+
+export type SoundtrackDocument = Soundtrack & Document;
+export const SoundtrackSchema = SchemaFactory.createForClass(Soundtrack);

--- a/src/soundtrack/soundtrack.controller.ts
+++ b/src/soundtrack/soundtrack.controller.ts
@@ -1,0 +1,24 @@
+import { Controller, Get, Param, Post } from '@nestjs/common';
+import { SoundtrackService } from './soundtrack.service';
+import { success } from 'src/common/helpers/response.helper';
+
+@Controller('soundtracks')
+export class SoundtrackController {
+  constructor(private readonly soundtrackService: SoundtrackService) {}
+
+  // GET /soundtracks/by-playlist/:id
+  @Get('by-playlist/:id')
+  async getSoundtracks(@Param('id') playlistId: string) {
+    const data = await this.soundtrackService.findByPlaylistId(playlistId);
+    return success(data, 'List soundtrack berhasil diambil');
+  }
+
+  // POST /soundtracks/:id/play
+  @Post(':id/play')
+  async incrementPlayCount(@Param('id') soundtrackId: string) {
+    const data = await this.soundtrackService.incrementPlayCount(soundtrackId);
+    return success(data, 'Play count updated');
+  }
+  
+  
+}

--- a/src/soundtrack/soundtrack.module.ts
+++ b/src/soundtrack/soundtrack.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { Soundtrack, SoundtrackSchema } from './entities/soundtrack.entity';
+import { SoundtrackController } from './soundtrack.controller';
+import { SoundtrackService } from './soundtrack.service';
+
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([
+      { name: Soundtrack.name, schema: SoundtrackSchema },
+    ]),
+  ],
+  controllers: [SoundtrackController],
+  providers: [SoundtrackService],
+})
+export class SoundtrackModule {}

--- a/src/soundtrack/soundtrack.seeder.ts
+++ b/src/soundtrack/soundtrack.seeder.ts
@@ -1,0 +1,38 @@
+import { Injectable, OnApplicationBootstrap } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model, Types } from 'mongoose';
+import { Soundtrack, SoundtrackDocument } from './entities/soundtrack.entity';
+
+@Injectable()
+export class SoundtrackSeeder implements OnApplicationBootstrap {
+  constructor(
+    @InjectModel(Soundtrack.name)
+    private soundtrackModel: Model<SoundtrackDocument>,
+  ) {}
+
+  async onApplicationBootstrap() {
+    const count = await this.soundtrackModel.countDocuments();
+    if (count === 0) {
+      const playlistId = new Types.ObjectId('6623df0f6bdc58f6f2a44a2e'); // ganti dengan id playlist kamu
+      await this.soundtrackModel.insertMany([
+        {
+          title: 'Rainy Mood',
+          artist: 'Pamungkas',
+          duration: 210,
+          audioUrl: 'https://domain.com/audio/rainy.mp3',
+          coverUrl: 'https://placehold.co/600x400?text=Rainy',
+          playlistId,
+        },
+        {
+          title: 'Sunshine Chill',
+          artist: 'Nadin Amizah',
+          duration: 180,
+          audioUrl: 'https://domain.com/audio/sunshine.mp3',
+          coverUrl: 'https://placehold.co/600x400?text=Sunshine',
+          playlistId,
+        },
+        // tambahin lagu lain sesuka hati 😎
+      ]);
+    }
+  }
+}

--- a/src/soundtrack/soundtrack.service.ts
+++ b/src/soundtrack/soundtrack.service.ts
@@ -1,0 +1,49 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model, Types } from 'mongoose';
+import { Soundtrack, SoundtrackDocument } from './entities/soundtrack.entity';
+import { SoundtrackDto } from './dto/soundtrack.dto';
+
+@Injectable()
+export class SoundtrackService {
+  constructor(
+    @InjectModel(Soundtrack.name)
+    private readonly soundtrackModel: Model<SoundtrackDocument>,
+  ) {}
+
+  async findByPlaylistId(playlistId: string): Promise<SoundtrackDto[]> {
+    if (!Types.ObjectId.isValid(playlistId)) {
+      throw new NotFoundException('Invalid playlist ID');
+    }
+
+    const tracks = await this.soundtrackModel
+      .find({ playlistId: new Types.ObjectId(playlistId) })
+      .sort({ createdAt: -1 })
+      .lean();
+
+    // Kalau pengen pakai exception
+    if (!tracks.length) {
+      throw new NotFoundException('No soundtracks found for this playlist');
+    }
+
+    return tracks.map((track) => ({
+      id: track._id.toString(),
+      title: track.title,
+      artist: track.artist,
+      duration: track.duration,
+      audioUrl: track.audioUrl,
+      coverUrl: track.coverUrl,
+    }));
+  }
+
+  async incrementPlayCount(id: string): Promise<{ playCount: number }> {
+    const updated = await this.soundtrackModel.findByIdAndUpdate(
+      id,
+      { $inc: { playCount: 1 } },
+      { new: true }, // penting biar dapet doc baru
+    );
+  
+    return { playCount: updated?.playCount ?? 0 };
+  }
+  
+}


### PR DESCRIPTION
- Added entity, schema, and seeder for soundtrack
- Linked soundtrack to playlist using playlistId
- Created endpoint to get soundtracks by playlist: GET /soundtracks/by-playlist/:id
- Added play count feature via POST /soundtracks/:id/play
- Automatically increments playCount each time track is played

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced soundtrack management, including a new module, controller, service, and database schema for soundtracks.
  - Added endpoints to retrieve soundtracks by playlist and to increment the play count for a soundtrack.
  - Implemented automatic seeding of initial soundtrack data if the collection is empty.

- **Improvements**
  - Enhanced playlist functionality by integrating soundtrack-related features into the playlist module.
  - Updated application module configuration for clearer module imports and improved global authentication and authorization handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->